### PR TITLE
Optimize io for pagerank

### DIFF
--- a/DArray/io.jl
+++ b/DArray/io.jl
@@ -5,11 +5,20 @@ Optimized function that writes list of edges as tab seperated values
 Tries to be perform as little allocation as possible
 """
 function writetsv(file, ij1, ij2)
+   arr = Vector{UInt8}(64)
    for (i, j) in zip(ij1, ij2)
-      write(file, dec(i))
-      write(file, '\t')
-      write(file, dec(j))
-      write(file, '\n')
+      nchars = dec!(arr, i)
+      writeto(file, arr, nchars)
+      write(file, UInt8('\t'))
+      nchars = dec!(arr, j)
+      writeto(file, arr, nchars)
+      write(file, UInt8('\n'))
+   end
+end
+
+function writeto(io, arr, nchars)
+   @inbounds for i in 1:nchars
+      write(io, arr[i])
    end
 end
 
@@ -23,6 +32,20 @@ function readtsv(file)
       push!(ij2, parseuntil(file,NL))
    end
    ij1, ij2
+end
+
+# Assumes positive number
+function dec!(arr::Vector{UInt8}, x::Int64)
+   nchars = i = Base.ndigits0z(x)
+   if i > length(arr) # only resize if array is to small
+      resize!(arr, i)
+   end
+   while i > 0
+      arr[i] = '0'+rem(x,10)
+      x ÷= 10
+      i -= 1
+   end
+   nchars
 end
 
 # Exploit the domain knowledge we have

--- a/DArray/io.jl
+++ b/DArray/io.jl
@@ -1,0 +1,42 @@
+using BufferedStreams
+
+"""
+Optimized function that writes list of edges as tab seperated values
+Tries to be perform as little allocation as possible
+"""
+function writetsv(file, ij1, ij2)
+   for (i, j) in zip(ij1, ij2)
+      write(file, dec(i))
+      write(file, '\t')
+      write(file, dec(j))
+      write(file, '\n')
+   end
+end
+
+function readtsv(file)
+   ij1 = Array{Int64}(0)
+   ij2 = Array{Int64}(0)
+   const TAB = UInt8('\t')
+   const NL = UInt8('\n')
+   while !eof(file)
+      push!(ij1, parseuntil(file,TAB))
+      push!(ij2, parseuntil(file,NL))
+   end
+   ij1, ij2
+end
+
+# Exploit the domain knowledge we have
+# Only positive numbers
+# Taken from CSV.jl
+function parseuntil(file, delim::UInt8)
+   v = 0
+   b = read(file, UInt8)
+   const ZERO = UInt8('0')
+   while b != delim
+      v *= 10
+      v += b - ZERO
+      b = read(file, UInt8)
+   end
+   v
+end
+

--- a/DArray/kronGraph500NoPerm.jl
+++ b/DArray/kronGraph500NoPerm.jl
@@ -1,5 +1,5 @@
 # change loop order to reduce loads and stores
-function kronGraph500NoPerm(scl, EdgesPerVertex)
+function kronGraph500NoPerm(scl, nEdges)
 # Graph500NoPerm: Generates graph edges using the same 2x2 Kronecker algorithm (R-MAT) as the Graph500 benchmark, but no permutation of vertex labels is performed.
 # IO user function.
 #   Usage:
@@ -11,20 +11,16 @@ function kronGraph500NoPerm(scl, EdgesPerVertex)
 #     StartVertex = M vector of integer start vertices in the range [1,N]
 #     EndVertex = M vector of integer end vertices in the range [1,N]
 
-    n = 2^scl                             # Set  power of number of vertices..
-
-    m = EdgesPerVertex * n                # Compute total number of edges to generate.
-
     a, b, c = 0.57, 0.19, 0.19
     d = 1 - (a + b + c)                   # Set R-MAT (2x2 Kronecker) coefficeints.
 
-    ij = Vector{Tuple{Int64, Int64}}(m)   # Initialize index arrays.
-    ab = a + b                            # Normalize coefficients.
+    ij = Vector{Tuple{Int64, Int64}}(nEdges)   # Initialize index arrays.
+    ab = a + b                                 # Normalize coefficients.
     c_norm = c/(1 - (a + b))
     a_norm = a/(a + b)
 
     randbuf = Vector{Float64}(2scl)
-    for i = 1:m
+    for i = 1:nEdges
         rand!(randbuf)
         ij1 = one(Int64)
         ij2 = one(Int64)

--- a/DArray/kronGraph500NoPerm.jl
+++ b/DArray/kronGraph500NoPerm.jl
@@ -1,5 +1,3 @@
-module PageRank
-
 # Almost literal translation of MATLAB code
 function kronGraph500NoPerm(scl, EdgesPerVertex)
 # Graph500NoPerm: Generates graph edges using the same 2x2 Kronecker algorithm (R-MAT) as the Graph500 benchmark, but no permutation of vertex labels is performed.
@@ -280,6 +278,4 @@ function kronGraph500NoPerm6(scl, EdgesPerVertex)
     end
 
     return ij1, ij2
-end
-
 end

--- a/DArray/kronGraph500NoPerm.jl
+++ b/DArray/kronGraph500NoPerm.jl
@@ -1,4 +1,4 @@
-# Almost literal translation of MATLAB code
+# change loop order to reduce loads and stores
 function kronGraph500NoPerm(scl, EdgesPerVertex)
 # Graph500NoPerm: Generates graph edges using the same 2x2 Kronecker algorithm (R-MAT) as the Graph500 benchmark, but no permutation of vertex labels is performed.
 # IO user function.
@@ -11,40 +11,6 @@ function kronGraph500NoPerm(scl, EdgesPerVertex)
 #     StartVertex = M vector of integer start vertices in the range [1,N]
 #     EndVertex = M vector of integer end vertices in the range [1,N]
 
-    n = 2^scl                          # Set  power of number of vertices..
-
-    m = EdgesPerVertex * n             # Compute total number of edges to generate.
-
-    a, b, c = 0.57, 0.19, 0.19
-    d = 1 - (a + b + c)                # Set R-MAT (2x2 Kronecker) coefficeints.
-
-    ij = ones(2, m)                    # Initialize index arrays.
-    ab = a + b                         # Normalize coefficients.
-    c_norm = c/(1 - (a + b))
-    a_norm = a/(a + b)
-
-    for ib = 1:scl                     # Loop over each scale.
-        ii_bit = rand(m) .> ab
-        jj_bit = rand(m) .> ( c_norm * ii_bit + a_norm * !(ii_bit) )
-        ij = ij + 2^(ib - 1) * [ii_bit'; jj_bit']
-    end
-
-    return ij[1,:], ij[2,:]
-end
-
-# Devectorize
-function kronGraph500NoPerm2(scl, EdgesPerVertex)
-# Graph500NoPerm: Generates graph edges using the same 2x2 Kronecker algorithm (R-MAT) as the Graph500 benchmark, but no permutation of vertex labels is performed.
-# IO user function.
-#   Usage:
-#     StartVertex EndVertex = Graph500NoPerm(scl, edgefactor)
-#   Inputs:
-#     scl = integer scale factor that sets the max number of vertices to 2^scl
-#     EdgesPerVertex = sets the total number of edges to M = K*N;
-#  Outputs:
-#     StartVertex = M vector of integer start vertices in the range [1,N]
-#     EndVertex = M vector of integer end vertices in the range [1,N]
-
     n = 2^scl                             # Set  power of number of vertices..
 
     m = EdgesPerVertex * n                # Compute total number of edges to generate.
@@ -52,113 +18,32 @@ function kronGraph500NoPerm2(scl, EdgesPerVertex)
     a, b, c = 0.57, 0.19, 0.19
     d = 1 - (a + b + c)                   # Set R-MAT (2x2 Kronecker) coefficeints.
 
-    ij1, ij2 = ones(Int, m), ones(Int, m) # Initialize index arrays.
+    ij = Vector{Tuple{Int64, Int64}}(m)   # Initialize index arrays.
     ab = a + b                            # Normalize coefficients.
     c_norm = c/(1 - (a + b))
     a_norm = a/(a + b)
 
-    for ib = -1:scl - 2                   # Loop over each scale.
-        @inbounds for i = 1:m
-            ii_bit  = rand() > ab
-            jj_bit  = rand() > ifelse(ii_bit, c_norm, a_norm)
-            sc      = 1 << ib
-            ij1[i] += sc * ii_bit
-            ij2[i] += sc * jj_bit
-        end
-    end
-
-    return ij1, ij2
-end
-
-# Move rng out of inner loop
-function kronGraph500NoPerm3(scl, EdgesPerVertex)
-# Graph500NoPerm: Generates graph edges using the same 2x2 Kronecker algorithm (R-MAT) as the Graph500 benchmark, but no permutation of vertex labels is performed.
-# IO user function.
-#   Usage:
-#     StartVertex EndVertex = Graph500NoPerm(scl, edgefactor)
-#   Inputs:
-#     scl = integer scale factor that sets the max number of vertices to 2^scl
-#     EdgesPerVertex = sets the total number of edges to M = K*N;
-#  Outputs:
-#     StartVertex = M vector of integer start vertices in the range [1,N]
-#     EndVertex = M vector of integer end vertices in the range [1,N]
-
-    n = 2^scl                             # Set  power of number of vertices..
-
-    m = EdgesPerVertex * n                # Compute total number of edges to generate.
-
-    a, b, c = 0.57, 0.19, 0.19
-    d = 1 - (a + b + c)                   # Set R-MAT (2x2 Kronecker) coefficeints.
-
-    ij1, ij2 = ones(Int, m), ones(Int, m) # Initialize index arrays.
-    ab = a + b                            # Normalize coefficients.
-    c_norm = c/(1 - (a + b))
-    a_norm = a/(a + b)
-
-    rand1buf = Array(Float64, m)
-    rand2buf = Array(Float64, m)
-    for ib = -1:scl - 2                   # Loop over each scale.
-        rand!(rand1buf)
-        rand!(rand2buf)
-        sc = 1 << ib
-        @inbounds for i = 1:m
-            ii_bit  = rand1buf[i] > ab
-            jj_bit  = rand2buf[i] > ifelse(ii_bit, c_norm, a_norm)
-            ij1[i] += sc * ii_bit
-            ij2[i] += sc * jj_bit
-        end
-    end
-
-    return ij1, ij2
-end
-
-# change loop order to reduce loads and stores
-function kronGraph500NoPerm4(scl, EdgesPerVertex)
-# Graph500NoPerm: Generates graph edges using the same 2x2 Kronecker algorithm (R-MAT) as the Graph500 benchmark, but no permutation of vertex labels is performed.
-# IO user function.
-#   Usage:
-#     StartVertex EndVertex = Graph500NoPerm(scl, edgefactor)
-#   Inputs:
-#     scl = integer scale factor that sets the max number of vertices to 2^scl
-#     EdgesPerVertex = sets the total number of edges to M = K*N;
-#  Outputs:
-#     StartVertex = M vector of integer start vertices in the range [1,N]
-#     EndVertex = M vector of integer end vertices in the range [1,N]
-
-    n = 2^scl                             # Set  power of number of vertices..
-
-    m = EdgesPerVertex * n                # Compute total number of edges to generate.
-
-    a, b, c = 0.57, 0.19, 0.19
-    d = 1 - (a + b + c)                   # Set R-MAT (2x2 Kronecker) coefficeints.
-
-    ij1, ij2 = Array(Int, m), Array(Int, m) # Initialize index arrays.
-    ab = a + b                            # Normalize coefficients.
-    c_norm = c/(1 - (a + b))
-    a_norm = a/(a + b)
-
-    randbuf = Array(Float64, 2scl)
+    randbuf = Vector{Float64}(2scl)
     for i = 1:m
         rand!(randbuf)
-        ij1_i = one(eltype(ij1))
-        ij2_i = one(eltype(ij2))
+        ij1 = one(Int64)
+        ij2 = one(Int64)
         @inbounds for ib = 1:scl                   # Loop over each scale.
             sc = 1 << (ib - 2)
             ii_bit  = randbuf[ib] > ab
             jj_bit  = randbuf[ib+scl] > ifelse(ii_bit, c_norm, a_norm)
-            ij1_i += sc * ii_bit
-            ij2_i += sc * jj_bit
+            ij1 += sc * ii_bit
+            ij2 += sc * jj_bit
         end
-        ij1[i] = ij1_i
-        ij2[i] = ij2_i
+        ij[i] = (ij1, ij2)
     end
 
-    return ij1, ij2
+    return ij
 end
 
 # FASTEST VERSION
 # With threading
-function kronGraph500NoPerm5(scl, EdgesPerVertex)
+function kronGraph500NoPermWithThreads(scl, EdgesPerVertex)
 # Graph500NoPerm: Generates graph edges using the same 2x2 Kronecker algorithm (R-MAT) as the Graph500 benchmark, but no permutation of vertex labels is performed.
 # IO user function.
 #   Usage:
@@ -177,7 +62,7 @@ function kronGraph500NoPerm5(scl, EdgesPerVertex)
     a, b, c = 0.57, 0.19, 0.19
     d = 1 - (a + b + c)                   # Set R-MAT (2x2 Kronecker) coefficeints.
 
-    ij1, ij2 = Array(Int, m), Array(Int, m) # Initialize index arrays.
+    ij = Vector{Tuple{Int64, Int64}}(m)   # Initialize index arrays.
     ab = a + b                            # Normalize coefficients.
     c_norm = c/(1 - (a + b))
     a_norm = a/(a + b)
@@ -186,96 +71,27 @@ function kronGraph500NoPerm5(scl, EdgesPerVertex)
     Base.Threads.@threads for l = 1:Threads.nthreads()
         # ccall(:jl_, Void, (Any,), Threads.threadid())
         r = Base.MersenneTwister(Threads.threadid())
-        randbuf = Array(Float64, 2scl)
+        randbuf = Vector{Float64}(2scl)
         range = 1:div(m, Threads.nthreads())
         lrange = length(range)*(Threads.threadid() - 1) + range
         for i = lrange
             # ccall(:jl_, Void, (Any,), i)
             # tl_randbuf = randbuf[Threads.threadid()]
             rand!(r, randbuf)
-            ij1_i = one(eltype(ij1))
-            ij2_i = one(eltype(ij2))
+            ij1 = one(Int)
+            ij2 = one(Int)
             @inbounds for ib = 1:scl                   # Loop over each scale.
                 sc = 1 << (ib - 2)
                 ii_bit  = randbuf[ib] > ab
                 jj_bit  = randbuf[ib+scl] > ifelse(ii_bit, c_norm, a_norm)
                 # ii_bit  = rand() > ab
                 # jj_bit  = rand() > ifelse(ii_bit, c_norm, a_norm)
-                ij1_i += sc * ii_bit
-                ij2_i += sc * jj_bit
+                ij1 += sc * ii_bit
+                ij2 += sc * jj_bit
             end
-            ij1[i] = ij1_i
-            ij2[i] = ij2_i
+            ij[i] = (ij1, ij2)
         end
     end
 
-    return ij1, ij2
-end
-
-# With threading
-function kronGraph500NoPerm6(scl, EdgesPerVertex)
-# Graph500NoPerm: Generates graph edges using the same 2x2 Kronecker algorithm (R-MAT) as the Graph500 benchmark, but no permutation of vertex labels is performed.
-# IO user function.
-#   Usage:
-#     StartVertex EndVertex = Graph500NoPerm(scl, edgefactor)
-#   Inputs:
-#     scl = integer scale factor that sets the max number of vertices to 2^scl
-#     EdgesPerVertex = sets the total number of edges to M = K*N;
-#  Outputs:
-#     StartVertex = M vector of integer start vertices in the range [1,N]
-#     EndVertex = M vector of integer end vertices in the range [1,N]
-
-    n = 2^scl                             # Set  power of number of vertices..
-
-    m = EdgesPerVertex * n                # Compute total number of edges to generate.
-
-    a, b, c = 0.57, 0.19, 0.19
-    d = 1 - (a + b + c)                   # Set R-MAT (2x2 Kronecker) coefficeints.
-
-    ij1, ij2 = Array(Int, m), Array(Int, m) # Initialize index arrays.
-    ab = a + b                            # Normalize coefficients.
-    c_norm = c/(1 - (a + b))
-    a_norm = a/(a + b)
-
-    @assert m % Threads.nthreads() == 0
-    gij1 = Array(Array{Float64, 1}, Threads.nthreads())
-    gij2 = Array(Array{Float64, 1}, Threads.nthreads())
-    Base.Threads.@threads for l = 1:Threads.nthreads()
-        # ccall(:jl_, Void, (Any,), Threads.threadid())
-        r = Base.MersenneTwister(Threads.threadid())
-        randbuf = Array(Float64, 2scl)
-        range = 1:div(m, Threads.nthreads())
-        lrange = length(range)*(Threads.threadid() - 1) + range
-        lij1 = Array(Int, length(range))
-        lij2 = Array(Int, length(range))
-        for i = range
-            # ccall(:jl_, Void, (Any,), i)
-            # tl_randbuf = randbuf[Threads.threadid()]
-            rand!(r, randbuf)
-            ij1_i = one(eltype(lij1))
-            ij2_i = one(eltype(lij2))
-            @inbounds for ib = 1:scl                   # Loop over each scale.
-                sc = 1 << (ib - 2)
-                ii_bit  = randbuf[ib] > ab
-                jj_bit  = randbuf[ib+scl] > ifelse(ii_bit, c_norm, a_norm)
-                # ii_bit  = rand() > ab
-                # jj_bit  = rand() > ifelse(ii_bit, c_norm, a_norm)
-                ij1_i += sc * ii_bit
-                ij2_i += sc * jj_bit
-            end
-            lij1[i] = ij1_i
-            lij2[i] = ij2_i
-        end
-        gij1[Threads.threadid()] = lij1
-        gij2[Threads.threadid()] = lij2
-    end
-
-    for l = 1:Threads.nthreads()
-        range = 1:div(m, Threads.nthreads())
-        lrange = length(range)*(l - 1) + range
-        ij1[range] = gij1[l]
-        ij2[range] = gij2[l]
-    end
-
-    return ij1, ij2
+    return ij
 end

--- a/DArray/kronGraph500NoPerm.jl
+++ b/DArray/kronGraph500NoPerm.jl
@@ -1,3 +1,8 @@
+function kronGraph500(filename, scl, nEdges)
+    edges = kronGraph500NoPerm(scl, nEdges)
+    writetsv(filename, edges)
+end
+
 # change loop order to reduce loads and stores
 function kronGraph500NoPerm(scl, nEdges)
 # Graph500NoPerm: Generates graph edges using the same 2x2 Kronecker algorithm (R-MAT) as the Graph500 benchmark, but no permutation of vertex labels is performed.

--- a/DArray/pagerank.jl
+++ b/DArray/pagerank.jl
@@ -1,11 +1,10 @@
 module Pagerank
 using DistributedArrays
-import DistributedArrays: map_localparts
 
 include("kronGraph500NoPerm.jl")
 include("io.jl")
 
-function kernel0(path, scl, EdgesPerVertes)
+function kernel0(filenames, scl, EdgesPerVertex)
    n = 2^scl
    m = EdgesPerVertex * n # Total number of vertices
 
@@ -13,29 +12,22 @@ function kernel0(path, scl, EdgesPerVertes)
    EdgesPerWorker = m ÷ nworkers()
    surplus = m % nworkers()
 
-   info("Generating data")
+   @assert length(filenames) == nworkers()
+
    lastWorker = maximum(workers())
-   @time begin
-      rrefs = map(workers()) do id
+   @sync begin
+      for (id, filename) in zip(workers(), filenames)
          nEdges = EdgesPerWorker
          nEdges += ifelse(id == lastWorker, surplus, 0)
-         kronGraph500NoPerm(scl, nEdges)
+         @async remotecall_wait(kronGraph500, id, filename, scl, nEdges)
       end
-      edges = DArray(rrefs)
    end
-
-   filenames = Dict(id => joinpath(path, "$i.tsv") for (id, i) in zip(workers(), 1:nworkers()))
-   info("Writing data:")
-   @time map_localparts(edges) do local_edges
-      writecsv(filename, filenames[myid()], local_edges)
-   end
-   return values(filenames)
 end
 
 function kernel1(filenames)
    info("Read data")
    @time begin
-      rrefs = map(zip(filennames, workers())) do iter
+      rrefs = map(zip(filenames, workers())) do iter
          filename, id = iter
          remotecall(readtsv, id, filename)
       end
@@ -51,8 +43,10 @@ function run(path, scl, EdgesPerVertex)
    info("EdgesPerVertex:", EdgesPerVertex)
    info("Number of workers: ", nworkers())
 
+   filenames = collect(joinpath(path, "$i.tsv") for i in 1:nworkers())
+
    info("Executing kernel 0")
-   @time filenames = kernel0(path, scl, EdgesPerVertex)
+   @time kernel0(filenames, scl, EdgesPerVertex)
 
    # Shuffle the filenames so that we minimise cache effect
    # TODO ideally we would like to make sure that no processor reads in

--- a/DArray/pagerank.jl
+++ b/DArray/pagerank.jl
@@ -1,0 +1,32 @@
+module Pagerank
+
+include("kronGraph500NoPerm.jl")
+include("io.jl")
+
+function run(scl, EdgesPerVertex)
+   info("Scale:", scl)
+   info("EdgesPerVertex:", EdgesPerVertex)
+   info("Number of threads: ", Threads.nthreads())
+
+   info("Generating data")
+   @time ij1, ij2 = kronGraph500NoPerm5(scl, EdgesPerVertex)
+
+   filename = "1.tsv"
+
+   info("Writing data:")
+   file = BufferedOutputStream(open(filename, "w"))
+   @time writetsv(file, ij1, ij2)
+   close(file)
+
+   info("Read data")
+   file = IOBuffer(Mmap.mmap(open(filename), Vector{UInt8}, (filesize(filename),)))
+   @time _ij1, _ij2 = readtsv(file)
+   close(file)
+
+   @assert all(ij1 .== _ij1)
+   @assert all(ij2 .== _ij2)
+   ij1, ij2
+end
+
+end
+

--- a/DArray/pagerank.jl
+++ b/DArray/pagerank.jl
@@ -34,11 +34,16 @@ end
 
 function kernel1(filenames)
    info("Read data")
-   rrefs = map(zip(filennames, workers())) do iter
-      filename, id = iter
-      remotecall(readtsv, id, filename)
+   @time begin
+      rrefs = map(zip(filennames, workers())) do iter
+         filename, id = iter
+         remotecall(readtsv, id, filename)
+      end
+      edges = DArray(rrefs)
    end
-   edges = DArray(rrefs)
+
+   info("Sort edges")
+   @time sort(edges)
 end
 
 function run(path, scl, EdgesPerVertex)
@@ -57,6 +62,10 @@ function run(path, scl, EdgesPerVertex)
    info("Executing kernel 1")
    @time kernel1(filenames)
 end
+
+# Two helper functions to make sort work on tuples
+Base.typemin{T}(::Type{Tuple{T,T}}) = (typemin(T),typemin(T))
+Base.typemax{T}(::Type{Tuple{T,T}}) = (typemax(T),typemax(T))
 
 end
 

--- a/DArray/pagerank.jl
+++ b/DArray/pagerank.jl
@@ -9,23 +9,18 @@ function run(scl, EdgesPerVertex)
    info("Number of threads: ", Threads.nthreads())
 
    info("Generating data")
-   @time ij1, ij2 = kronGraph500NoPerm5(scl, EdgesPerVertex)
+   @time ij = kronGraph500NoPerm(scl, EdgesPerVertex)
 
    filename = "1.tsv"
 
    info("Writing data:")
-   file = BufferedOutputStream(open(filename, "w"))
-   @time writetsv(file, ij1, ij2)
-   close(file)
+   @time writetsv(filename, ij)
 
    info("Read data")
-   file = IOBuffer(Mmap.mmap(open(filename), Vector{UInt8}, (filesize(filename),)))
-   @time _ij1, _ij2 = readtsv(file)
-   close(file)
+   @time _ij = readtsv(filename)
 
-   @assert all(ij1 .== _ij1)
-   @assert all(ij2 .== _ij2)
-   ij1, ij2
+   @assert all(ij .== _ij)
+   ij
 end
 
 end

--- a/DArray/pagerank.jl
+++ b/DArray/pagerank.jl
@@ -1,26 +1,40 @@
 module Pagerank
+using DistributedArrays
+import DistributedArrays: map_localparts
 
 include("kronGraph500NoPerm.jl")
 include("io.jl")
 
-function run(scl, EdgesPerVertex)
-   info("Scale:", scl)
-   info("EdgesPerVertex:", EdgesPerVertex)
-   info("Number of threads: ", Threads.nthreads())
-
+function kernel0(path, scl, EdgesPerVertes)
    info("Generating data")
-   @time ij = kronGraph500NoPerm(scl, EdgesPerVertex)
-
-   filename = "1.tsv"
+   @time edges = DArray(I->kronGraph500NoPerm(scl, EdgesPerVertes), (nworkers(), ))
 
    info("Writing data:")
-   @time writetsv(filename, ij)
+   @time map_localparts(edges) do local_edges
+      filename = joinpath(path, "$(myid()).tsv")
+      writecsv(filename, local_edges)
+   end
+end
 
+function kernel1(path)
    info("Read data")
-   @time _ij = readtsv(filename)
+   rrefs = map(workers()) do id
+      filename = joinpath(path, "$id.tsv")
+      remotecall(readtsv, id, filename)
+   end
+   edges = DArray(rrefs)
+end
 
-   @assert all(ij .== _ij)
-   ij
+function run(path, scl, EdgesPerVertex)
+   info("Scale:", scl)
+   info("EdgesPerVertex:", EdgesPerVertex)
+   info("Number of workers: ", nworkers())
+
+   info("Executing kernel 0")
+   @time kernel0(path, scl, EdgesPerVertex)
+
+   info("Executing kernel 1")
+   @time kernel1(path)
 end
 
 end


### PR DESCRIPTION
Currently writing data is the slowest part. This is mostly due to the
fact that `dec(i)` is allocating an array to do the conversion. In
general our IO is quite bad at doing operations without allocation.

MMap'ing the input array is a huge speed boost as well as taking care
that parsing is not allocating.

This uses BufferedStreams.jl to make `write` cheaper.
